### PR TITLE
fix: updates logic to get release information

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set environment information for schedule
         if: ${{ steps.check_event.outputs.event_type == 'schedule' }}
         run: |
-          LATEST_VERSION=$( gh release view --json tagName --jq '.["tagName"]' )      
+          LATEST_VERSION=$(curl --silent -m 10 --connect-timeout 5 https://api.github.com/repos/complytime/trestle-bot/releases/latest | jq .tag_name)      
           {
             echo "TAG=$LATEST_VERSION"
             echo "NO_CACHE=true"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set environment information for schedule
         if: ${{ steps.check_event.outputs.event_type == 'schedule' }}
         run: |
-          LATEST_VERSION=$(curl --silent -m 10 --connect-timeout 5 https://api.github.com/repos/complytime/trestle-bot/releases/latest | jq .tag_name)      
+          LATEST_VERSION=$(curl --silent -m 10 --connect-timeout 5 https://api.github.com/repos/complytime/trestle-bot/releases/latest | jq -r .tag_name)      
           {
             echo "TAG=$LATEST_VERSION"
             echo "NO_CACHE=true"


### PR DESCRIPTION
## Description

Using the gh CLI requires the repository to already be cloned. The publish.yml clones the repository based on input, so the latest release is updated to pull the information in a way that does not require a local copy of the repo.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] TBD

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
