### PR TITLE
fix: CPLYTM-516 list index out of range error

### DIFF
--- a/trestlebot/bot.py
+++ b/trestlebot/bot.py
@@ -148,18 +148,22 @@ class TrestleBot:
     def _get_committed_files(self, commit: Commit) -> List[str]:
         """Get the list of committed files in the commit."""
         changes: List[str] = []
-        diffs = {diff.a_path: diff for diff in commit.parents[0].diff(commit)}
-        for path in commit.stats.files.keys():
-            diff = diffs.get(path, None)
-            if diff:
-                if diff.change_type == "A":
-                    changes.append(f"{path} [added]")
-                elif diff.change_type == "M":
-                    changes.append(f"{path} [modified]")
-                elif diff.change_type == "D":
-                    changes.append(f"{path} [deleted]")
-                elif diff.change_type == "R":
-                    changes.append(f"{path} [renamed]")
+        if commit.parents:
+            diffs = {diff.a_path: diff for diff in commit.parents[0].diff(commit)}
+            for path in commit.stats.files.keys():
+                diff = diffs.get(path, None)
+                if diff:
+                    if diff.change_type == "A":
+                        changes.append(f"{path} [added]")
+                    elif diff.change_type == "M":
+                        changes.append(f"{path} [modified]")
+                    elif diff.change_type == "D":
+                        changes.append(f"{path} [deleted]")
+                    elif diff.change_type == "R":
+                        changes.append(f"{path} [renamed]")
+        else:
+            for path in commit.stats.files.keys():
+                changes.append(f"{path} [added]")
         return changes
 
     def run(


### PR DESCRIPTION
## Description

Fixes CPLYTM-516,  Trestle-bot Error: list index out of range 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
