### PR TITLE
feat: Introduce sync-oscal-content cmd, implemented parameters validation and sync

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           name: coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # pin@49e6cd3b187936a73b8280d59ffd9da69df63ec9
+        uses: SonarSource/sonarqube-scan-action@f932b663acf3c4b8b27c673927b5ac744638b17b # pin@f932b663acf3c4b8b27c673927b5ac744638b17b
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/tests/data/json/rhel8.json
+++ b/tests/data/json/rhel8.json
@@ -1,0 +1,243 @@
+{
+  "component-definition": {
+    "uuid": "5d34623f-d243-4cba-99f0-663be3df8dfa",
+    "metadata": {
+      "title": "Component definition for rhel8",
+      "last-modified": "2025-02-21T09:20:55.751305+00:00",
+      "version": "1.0",
+      "oscal-version": "1.1.2"
+    },
+    "components": [
+      {
+        "uuid": "284ad08b-e8df-432a-b02a-3936983f9daa",
+        "type": "service",
+        "title": "rhel8",
+        "description": "Red Hat Enterprise Linux 8",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "configure_crypto_policy",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Test Configure System Cryptography Policy",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_sshd_set_keepalive",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Specify the maximum number of idle message counts before session is terminated.",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{10: 10, 3: 3, 5: 5, 0: 0, 1: 1, 'default': 0}",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_system_crypto_policy",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Specify the crypto policy for the system.",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{'default': 'DEFAULT', 'default_policy': 'DEFAULT', 'default_nosha1': 'DEFAULT:NO-SHA1', 'fips': 'FIPS', 'fips_ospp': 'FIPS:OSPP', 'legacy': 'LEGACY', 'future': 'FUTURE', 'next': 'NEXT'}",
+            "remarks": "rule_set_0"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "file_groupownership_sshd_private_key",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Test Verify Group Ownership on SSH Server Private *_key Key Files",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_sshd_set_keepalive",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Specify the maximum number of idle message counts before session is terminated.",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{10: 10, 3: 3, 5: 5, 0: 0, 1: 1, 'default': 0}",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_system_crypto_policy",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Specify the crypto policy for the system.",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{'default': 'DEFAULT', 'default_policy': 'DEFAULT', 'default_nosha1': 'DEFAULT:NO-SHA1', 'fips': 'FIPS', 'fips_ospp': 'FIPS:OSPP', 'legacy': 'LEGACY', 'future': 'FUTURE', 'next': 'NEXT'}",
+            "remarks": "rule_set_1"
+          },
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "sshd_set_keepalive",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Test Set SSH Client Alive Count Max",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_sshd_set_keepalive",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Specify the maximum number of idle message counts before session is terminated.",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{10: 10, 3: 3, 5: 5, 0: 0, 1: 1, 'default': 0}",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "var_system_crypto_policy",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "Specify the crypto policy for the system.",
+            "remarks": "rule_set_2"
+          },
+          {
+            "name": "Parameter_Value_Alternatives",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "{'default': 'DEFAULT', 'default_policy': 'DEFAULT', 'default_nosha1': 'DEFAULT:NO-SHA1', 'fips': 'FIPS', 'fips_ospp': 'FIPS:OSPP', 'legacy': 'LEGACY', 'future': 'FUTURE', 'next': 'NEXT'}",
+            "remarks": "rule_set_2"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "6ef3a566-1c8e-41b5-b448-6c12f9b8b9a9",
+            "source": "trestle://profiles/simplified_nist_profile/profile.json",
+            "description": "REPLACE_ME",
+            "props": [
+              {
+                "name": "Framework_Short_Name",
+                "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
+                "value": "example"
+              }
+            ],
+            "set-parameters": [
+              {
+                "param-id": "var_system_crypto_policy",
+                "values": [
+                  "future"
+                ]
+              },
+              {
+                "param-id": "no-exist-param",
+                "values": [
+                  "fips"
+                ]
+              },
+              {
+                "param-id": "var_password_pam_minlen",
+                "values": [
+                  "15"
+                ]
+              }
+            ],
+            "implemented-requirements": [
+              {
+                "uuid": "7137b96b-4971-42df-8a83-a461822bdfff",
+                "control-id": "ac-2",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "alternative",
+                    "remarks": "REPLACE_ME"
+                  }
+                ]
+              },
+              {
+                "uuid": "bb911492-3a1a-468b-8c99-4d980470c8fc",
+                "control-id": "ac-1",
+                "description": "REPLACE_ME",
+                "props": [
+                  {
+                    "name": "implementation-status",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "implemented"
+                  },
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "file_groupownership_sshd_private_key"
+                  }
+                ],
+                "statements": [
+                  {
+                    "statement-id": "ac-1_smt.a",
+                    "uuid": "7dacd3e5-4832-4c35-9231-1cda8bce2c11",
+                    "description": "AC-1(a) is an organizational control outside the scope of OpenShift configuration."
+                  },
+                  {
+                    "statement-id": "ac-1_smt.b",
+                    "uuid": "7f4d1616-a32f-4e5c-8c35-835bcc85b603",
+                    "description": "AC-1(b) is an organizational control outside the scope of OpenShift configuration."
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -6,6 +6,7 @@
 
 import argparse
 import logging
+import os
 import pathlib
 import shutil
 import tempfile
@@ -230,6 +231,22 @@ def setup_for_compdef(
     )
 
     return args
+
+
+def setup_for_cac_content_dir(tmp_dir: str, cac_content_src_dir: pathlib.Path) -> None:
+    """
+    Setup cac content dir for testing
+    """
+    shutil.copytree(cac_content_src_dir, tmp_dir, dirs_exist_ok=True)
+
+    # modify abcd-levels.yml control file for sync OSCAL content testing
+    abcd_levels_control_file_path = os.path.join(tmp_dir, "controls", "abcd-levels.yml")
+    replace_string_in_file(
+        abcd_levels_control_file_path,
+        "rules: []",
+        "rules:\n      - file_groupownership_sshd_private_key\n"
+        "      - var_sshd_set_keepalive=1\n      - var_system_crypto_policy=fips",
+    )
 
 
 def setup_rules_view(

--- a/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Red Hat, Inc.
+
+"""Unit test for sync-cac-content command"""
+import os.path
+import pathlib
+from typing import Tuple
+
+from click.testing import CliRunner
+from git import Repo
+from ruamel.yaml import YAML
+
+from tests.testutils import TEST_DATA_DIR, setup_for_cac_content_dir, setup_for_compdef
+from trestlebot.cli.commands.sync_oscal_content import (
+    sync_oscal_cd_to_cac_control_files_cmd,
+    sync_oscal_content_cmd,
+)
+from trestlebot.const import INVALID_ARGS_EXIT_CODE, SUCCESS_EXIT_CODE
+
+
+test_product = "rhel8"
+# Note: data in test_content_dir is copied from content repo, PR:
+# https://github.com/ComplianceAsCode/content/pull/12819
+test_content_dir = TEST_DATA_DIR / "content_dir"
+
+
+def test_invalid_sync_oscal_cmd() -> None:
+    """Tests that sync-oscal-content command fails if given invalid subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(sync_oscal_content_cmd, ["invalid"])
+
+    assert "Error: No such command 'invalid'" in result.output
+    assert result.exit_code == INVALID_ARGS_EXIT_CODE
+
+
+def test_sync_oscal_cd_to_cac_control(
+    tmp_repo: Tuple[str, Repo], tmp_init_dir: str
+) -> None:
+    """Tests sync OSCAL component definition to cac control file."""
+    repo_dir, _ = tmp_repo
+    trestle_repo_path = pathlib.Path(repo_dir)
+    setup_for_compdef(trestle_repo_path, test_product, test_product)
+    tmp_content_dir = tmp_init_dir
+    setup_for_cac_content_dir(tmp_content_dir, test_content_dir)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        sync_oscal_cd_to_cac_control_files_cmd,
+        [
+            "--product",
+            test_product,
+            "--cac-content-root",
+            tmp_content_dir,
+            "--repo-path",
+            str(trestle_repo_path.resolve()),
+            "--committer-email",
+            "test@email.com",
+            "--committer-name",
+            "test name",
+            "--branch",
+            "test",
+            "--dry-run",
+        ],
+    )
+
+    # Check the CLI sync-cac-content is successful
+    assert result.exit_code == SUCCESS_EXIT_CODE, result.output
+
+    yaml = YAML()
+
+    # check profile
+    profile_path = pathlib.Path(
+        os.path.join(tmp_content_dir, "products/rhel8/profiles/example.profile")
+    )
+
+    profile_data = yaml.load(profile_path)
+    selections_field = profile_data["selections"]
+    assert "abcd-levels:all:medium" in selections_field
+    assert "file_groupownership_sshd_private_key" in selections_field
+    assert "sshd_set_keepalive" in selections_field
+    assert "var_password_pam_minlen=15" in selections_field
+    assert "var_sshd_set_keepalive=1" not in selections_field
+
+    # check control file
+    control_file_path = pathlib.Path(
+        os.path.join(tmp_content_dir, "controls", "abcd-levels.yml")
+    )
+    control_file_data = yaml.load(control_file_path)
+    for control in control_file_data["controls"]:
+        if control["id"] == "AC-1":
+            rules = control.get("rules", [])
+            assert "file_groupownership_sshd_private_key" in rules
+            assert "var_system_crypto_policy=future" in rules
+            assert "var_sshd_set_keepalive=1" not in rules
+        elif control["id"] == "AC-2":
+            rules = control.get("rules", [])
+            assert rules == []

--- a/trestlebot/cli/commands/sync_oscal_content.py
+++ b/trestlebot/cli/commands/sync_oscal_content.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Red Hat, Inc.
+
+"""Module for sync OSCAL models to cac content command"""
+import logging
+import pathlib
+from typing import Any, List
+
+import click
+
+from trestlebot.cli.options.common import common_options, git_options, handle_exceptions
+from trestlebot.cli.utils import run_bot
+from trestlebot.tasks.base_task import TaskBase
+from trestlebot.tasks.sync_oscal_content_task import SyncOscalCdTask
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.group(name="sync-oscal-content", help="Sync OSCAL models to cac content.")
+@click.pass_context
+@handle_exceptions
+def sync_oscal_content_cmd(ctx: click.Context) -> None:
+    """
+    Command to sync OSCAL models to cac content
+    """
+
+
+@sync_oscal_content_cmd.command(
+    name="cac-control",
+    help="Sync OSCAL component definition to cac control file.",
+)
+@click.pass_context
+@common_options
+@git_options
+@click.option(
+    "--cac-content-root",
+    help="Root of the CaC content project.",
+    type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.option(
+    "--product",
+    type=str,
+    help="Component title in OSCAL component definition that to find which component to sync",
+    required=True,
+)
+def sync_oscal_cd_to_cac_control_files_cmd(
+    ctx: click.Context,
+    cac_content_root: pathlib.Path,
+    product: str,
+    **kwargs: Any,
+) -> None:
+    """Sync OSCAL component definition to cac control file"""
+    working_dir = kwargs["repo_path"]  # From common_options
+    pre_tasks: List[TaskBase] = []
+    sync_cac_content_task = SyncOscalCdTask(
+        cac_content_root=cac_content_root, working_dir=working_dir, product=product
+    )
+    pre_tasks.append(sync_cac_content_task)
+    result = run_bot(pre_tasks, kwargs)
+    logger.debug(f"Trestlebot results: {result}")

--- a/trestlebot/cli/root.py
+++ b/trestlebot/cli/root.py
@@ -14,6 +14,7 @@ from trestlebot.cli.commands.sync_cac_content import (
     sync_cac_catalog_cmd,
     sync_cac_content_cmd,
 )
+from trestlebot.cli.commands.sync_oscal_content import sync_oscal_content_cmd
 from trestlebot.cli.commands.sync_upstreams import sync_upstreams_cmd
 
 
@@ -40,6 +41,7 @@ root_cmd.add_command(rules_transform_cmd)
 root_cmd.add_command(sync_cac_catalog_cmd)
 root_cmd.add_command(sync_cac_content_cmd)
 root_cmd.add_command(sync_upstreams_cmd)
+root_cmd.add_command(sync_oscal_content_cmd)
 
 if __name__ == "__main__":
     root_cmd()

--- a/trestlebot/tasks/sync_oscal_content_task.py
+++ b/trestlebot/tasks/sync_oscal_content_task.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Red Hat, Inc.
+
+"""Trestle Bot Sync OSCAL models to cac content Tasks"""
+import logging
+import os.path
+import pathlib
+from typing import Any, Dict, List
+
+from ruamel.yaml import YAML
+from ssg.profiles import ProfileSelections, get_profiles_from_products
+from ssg.variables import get_variable_options
+from trestle.common.model_utils import ModelUtils
+from trestle.core.models.file_content_type import FileContentType
+from trestle.core.profile_resolver import ProfileResolver
+from trestle.oscal.component import (
+    ComponentDefinition,
+    ControlImplementation,
+    DefinedComponent,
+    ImplementedRequirement,
+    SetParameter,
+)
+
+from trestlebot.const import FRAMEWORK_SHORT_NAME, SUCCESS_EXIT_CODE
+from trestlebot.tasks.authored.profile import CatalogControlResolver
+from trestlebot.tasks.base_task import TaskBase
+from trestlebot.utils import populate_if_dict_field_not_exist
+
+
+logger = logging.getLogger(__name__)
+
+
+class ParameterDiffInfo:
+    """
+    Parameter difference info between OSCAL component definition and cac content
+    """
+
+    def __init__(
+        self,
+        cac_content_root: pathlib.Path,
+        profile_variables: Dict[str, str],
+        oscal_parameters: List[SetParameter],
+    ):
+        """
+        Deal with parameter difference when init
+        """
+        self.cac_content_root = cac_content_root
+        self._parameters_add: List[SetParameter] = []
+        self._parameters_update: Dict[str, List[str]] = {}
+        self._parameters_remove: List[str] = [
+            v
+            for v in profile_variables
+            if v not in [parameter.param_id for parameter in oscal_parameters]
+        ]
+        for parameter in oscal_parameters:
+            if parameter.param_id not in profile_variables:
+                self._parameters_add.append(parameter)
+            elif profile_variables[parameter.param_id] not in parameter.values:
+                self._parameters_update[parameter.param_id] = parameter.values
+
+    @property
+    def parameters_add(self) -> List[SetParameter]:
+        return self._parameters_add
+
+    @property
+    def parameters_update(self) -> Dict[str, List[str]]:
+        return self._parameters_update
+
+    @property
+    def parameters_remove(self) -> List[str]:
+        return self._parameters_remove
+
+    def validate_variables(self) -> None:
+        """
+        Validate new variables need to added/update exists in cac content, remove from parameters_add
+        if it's invalid
+        """
+        for parameter in self._parameters_add:
+            all_options = get_variable_options(
+                self.cac_content_root, parameter.param_id
+            )
+            if not all_options:
+                logger.warning(
+                    f"variable {parameter.param_id} not found in cac content"
+                )
+                self._parameters_add.remove(parameter)
+                continue
+
+            for v in parameter.values:
+                if v not in all_options:
+                    logger.warning(
+                        f"variable {parameter.param_id} not have {v} option in cac content"
+                    )
+                    parameter.values.remove(v)
+
+        for param_id, param_values in self._parameters_update.items():
+            all_options = get_variable_options(self.cac_content_root, param_id)
+
+            for v in param_values:
+                if v not in all_options:
+                    logger.warning(
+                        f"variable {parameter.param_id} not have {v} option in cac content"
+                    )
+                    self._parameters_update[param_id].remove(v)
+
+    def __str__(self) -> str:
+        return (
+            f"Parameters added: {self.parameters_add}, Parameters updated: {self.parameters_update},"
+            f" Parameters remove: {self.parameters_remove}"
+        )
+
+
+class SyncOscalCdTask(TaskBase):
+    """Sync OSCAL component definition to cac content task."""
+
+    def __init__(
+        self, cac_content_root: pathlib.Path, working_dir: str, product: str
+    ) -> None:
+        """Initialize task."""
+        super().__init__(working_dir, None)
+        self.cac_content_root = cac_content_root
+        self.product = product
+        self.control_dir = os.path.join(self.cac_content_root, "controls")
+        self.parameter_diff_info: ParameterDiffInfo = ParameterDiffInfo(
+            self.cac_content_root, {}, []
+        )
+        self.implemented_requirement_dict: Dict[str, ImplementedRequirement] = {}
+        self.catalog_helper: CatalogControlResolver = CatalogControlResolver()
+
+    @staticmethod
+    def read_ordered_data_from_yaml(file_path: pathlib.Path) -> Any:
+        """
+        Read data from yaml file while preserving the order of dictionaries
+        """
+        yaml = YAML()
+        return yaml.load(file_path)
+
+    @staticmethod
+    def write_ordered_data_to_yaml(
+        file_path: pathlib.Path, data: Any, is_profile: bool = False
+    ) -> None:
+        """
+        Serializes a Python object into a YAML stream, preserving the order of dictionaries.
+        """
+        yaml = YAML()
+        # profile indent
+        if is_profile:
+            yaml.indent(mapping=4, sequence=4, offset=4)
+        yaml.dump(data, file_path)
+
+    def _update_selections_rules_in_memory(
+        self, rule_list: List[str], add_params: bool = True
+    ) -> List[str]:
+        """
+        In memory update selections/rules field of cac content
+        return: policy id list
+        """
+        policy_ids = []
+        removed_variable = []
+        for rule_index, rule in enumerate(rule_list):
+            if ":" in rule:
+                # policy
+                policy_ids.append(rule.split(":", maxsplit=1)[0])
+            elif "=" in rule:
+                # variable
+                v_id, v_value = rule.split("=")
+                if v_id in self.parameter_diff_info.parameters_update:
+                    # update variable
+                    for v in self.parameter_diff_info.parameters_update[v_id]:
+                        rule_list[rule_index] = f"{v_id}={v}"
+                elif v_id in self.parameter_diff_info.parameters_remove:
+                    removed_variable.append(rule)
+            else:
+                # rule
+                pass
+
+        # remove variables
+        for v in removed_variable:
+            rule_list.remove(v)
+
+        if not add_params:
+            return policy_ids
+
+        # add variables
+        for p in self.parameter_diff_info.parameters_add:
+            for v in p.values:
+                rule_list.append(f"{p.param_id}={v}")
+
+        return policy_ids
+
+    def _handle_controls_field(self, controls_data: List[Dict[str, Any]]) -> None:
+        """
+        Handle control file's controls field update
+        """
+        for control in controls_data:
+            sub_control = control.get("controls", [])
+            # recursively deal the sub controls of a control
+            if sub_control:
+                self._handle_controls_field(sub_control)
+
+            if (
+                self.catalog_helper.get_id(control["id"])
+                not in self.implemented_requirement_dict
+            ):
+                continue
+
+            # get rules field
+            rules = populate_if_dict_field_not_exist(control, "rules", [])
+            self._update_selections_rules_in_memory(rules, add_params=False)
+
+    def sync_to_control_file(self, control_file_path: pathlib.Path) -> None:
+        """
+        Sync component definition data to control file
+        """
+        control_file_data = self.read_ordered_data_from_yaml(control_file_path)
+        controls = control_file_data.get("controls", [])
+        self._handle_controls_field(controls)
+        self.write_ordered_data_to_yaml(control_file_path, control_file_data)
+
+    def sync(self, profile_id: str) -> None:
+        """
+        Sync OSCAL component definition data start from a cac content profile.
+        """
+        profile_path = pathlib.Path(
+            os.path.join(
+                self.cac_content_root,
+                "products",
+                self.product,
+                "profiles",
+                f"{profile_id}.profile",
+            )
+        )
+        # sync profile
+        # get profile data from yaml
+        profile_data = self.read_ordered_data_from_yaml(profile_path)
+
+        selections = populate_if_dict_field_not_exist(profile_data, "selections", [])
+
+        # Handle selections field, update profile file
+        # handle variables
+        policy_ids = self._update_selections_rules_in_memory(selections)
+
+        # save profile change
+        self.write_ordered_data_to_yaml(profile_path, profile_data, is_profile=True)
+
+        # sync control file
+        for policy_id in policy_ids:
+            control_file_path = pathlib.Path(
+                os.path.join(self.control_dir, f"{policy_id}.yml")
+            )
+            self.sync_to_control_file(control_file_path)
+
+    def make_implemented_requirements_as_dict(
+        self, control_implementation: ControlImplementation
+    ) -> None:
+        """
+        Transform OSCAL implemented-requirements field as dict for later use, control-id as key,
+        implemented-requirement object as value
+        """
+        self.implemented_requirement_dict.clear()
+        for implemented_requirement in control_implementation.implemented_requirements:
+            self.implemented_requirement_dict[implemented_requirement.control_id] = (
+                implemented_requirement
+            )
+
+    def execute(self) -> int:
+        # get component definition path according to product name
+        cd_json_path = ModelUtils.get_model_path_for_name_and_class(
+            self.working_dir, self.product, ComponentDefinition, FileContentType.JSON
+        )
+
+        logger.debug(f"Start to load {cd_json_path}")
+        component_definition = ComponentDefinition.oscal_read(cd_json_path)
+        if not component_definition:
+            raise RuntimeError(f"Read Component Definition from {cd_json_path} failed")
+
+        # find the component to sync
+        component: DefinedComponent
+        for cd in component_definition.components:
+            if cd.title == self.product:
+                component = cd
+                break
+        else:
+            raise RuntimeError(f"Component {self.product} not found in {cd_json_path}")
+        logger.debug(f"Start to sync component {component.title}")
+
+        # handle multiple control_implementations
+        for control_implementation in component.control_implementations:
+            # find profile id in 'props' field
+            for property_obj in control_implementation.props:
+                if property_obj.name == FRAMEWORK_SHORT_NAME:
+                    profile_id = property_obj.value
+                    break
+            else:
+                raise RuntimeError(
+                    f"profile_id not found for component {component.title}"
+                )
+
+            logger.debug(f"Found cac profile id: {profile_id}")
+            self.make_implemented_requirements_as_dict(control_implementation)
+            # use CatalogControlResolver to get control id map between cac and OSCAL
+            catalog_helper = CatalogControlResolver()
+            profile_resolver = ProfileResolver()
+            resolved_catalog = profile_resolver.get_resolved_profile_catalog(
+                pathlib.Path(self.working_dir),
+                control_implementation.source,
+                block_params=False,
+                params_format="[.]",
+                show_value_warnings=True,
+            )
+            catalog_helper.load(resolved_catalog)
+            self.catalog_helper = catalog_helper
+
+            # check parameters diff
+            profiles = get_profiles_from_products(self.cac_content_root, [self.product])
+            profile_selection_obj: ProfileSelections
+            for profile in profiles:
+                if profile.profile_id == profile_id:
+                    logger.info(f"profile {profile_id} variables: {profile.variables}")
+                    profile_selection_obj = profile
+                    break
+
+            diff = ParameterDiffInfo(
+                self.cac_content_root,
+                profile_selection_obj.variables,
+                control_implementation.set_parameters,
+            )
+            diff.validate_variables()
+            logger.info(f"parameters diff: {diff}")
+            self.parameter_diff_info = diff
+            # sync
+            self.sync(profile_id)
+
+        return SUCCESS_EXIT_CODE

--- a/trestlebot/utils.py
+++ b/trestlebot/utils.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Red Hat, Inc.
+
+"""Common utility functions."""
+from typing import Any, Dict
+
+
+def populate_if_dict_field_not_exist(
+    data: Dict[str, Any], field_name: str, default_value: Any
+) -> Any:
+    """
+    Set field with default value if a dict field does not exist,
+    if filed exists, this is a no-op
+    return field value
+    """
+    if data.get(field_name) is None:
+        data[field_name] = default_value
+
+    return data[field_name]


### PR DESCRIPTION
## Description

Introduce sync-oscal-content cmd, sync OSCAL component definition information to cac, implemented parameters validation and sync.

<img width="1328" alt="Screenshot 2025-02-26 at 17 00 43" src="https://github.com/user-attachments/assets/45670878-b141-49e4-8bcf-fde6bd2cbb90" />

Sample cmd:

```shell
poetry run trestlebot sync-oscal-content cac-control --branch main --cac-content-root ~/content --committer-name axuan --committer-email axuan@redhat.com --dry-run --repo-path ~/trestlebot-workspace --product ocp4
```

Fixes CPLYTM-544

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] Unit test
- [x] Manual test

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
