### PR TITLE
feat: Add comment to corresponding control when find missing rule

### DIFF
--- a/docs/tutorials/sync-oscal-content.md
+++ b/docs/tutorials/sync-oscal-content.md
@@ -12,6 +12,7 @@ The CLI performs the following sync:
 
 - Sync OSCAL component definition parameters/rules changes to CaC content profile file
 - Sync OSCAL component definition parameters/rules changes to CaC content control file
+- Add a hint comment to the control file when a missing rule is found in the CaC content repo.
 
 ### 1. Prerequisites
 

--- a/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
@@ -16,6 +16,7 @@ from trestlebot.cli.commands.sync_oscal_content import (
     sync_oscal_content_cmd,
 )
 from trestlebot.const import INVALID_ARGS_EXIT_CODE, SUCCESS_EXIT_CODE
+from trestlebot.utils import get_comments_from_yaml_data
 
 
 test_product = "rhel8"
@@ -89,6 +90,11 @@ def test_sync_oscal_cd_to_cac_control(
     control_file_data = yaml.load(control_file_path)
     for control in control_file_data["controls"]:
         if control["id"] == "AC-1":
+            # get comment, check if missing rule comment exists
+            exist_comments = get_comments_from_yaml_data(control)
+            assert len(exist_comments) == 1
+            comment = "TODO need to implement rule not_exist_rule_id"
+            assert len([True for c in exist_comments if comment in c]) == 1
             rules = control.get("rules", [])
             assert "file_groupownership_sshd_private_key" not in rules
             assert "var_system_crypto_policy=future" in rules

--- a/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
@@ -93,7 +93,7 @@ def test_sync_oscal_cd_to_cac_control(
             # get comment, check if missing rule comment exists
             exist_comments = get_comments_from_yaml_data(control)
             assert len(exist_comments) == 1
-            comment = "TODO need to implement rule not_exist_rule_id"
+            comment = "TODO: Need to implement rule not_exist_rule_id"
             assert len([True for c in exist_comments if comment in c]) == 1
             rules = control.get("rules", [])
             assert "file_groupownership_sshd_private_key" not in rules

--- a/trestlebot/tasks/sync_oscal_content_task.py
+++ b/trestlebot/tasks/sync_oscal_content_task.py
@@ -8,6 +8,7 @@ import pathlib
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedOrderedMap
 from ssg.constants import BENCHMARKS
 from ssg.profiles import ProfileSelections, get_profiles_from_products
 from ssg.rules import find_rule_dirs, get_rule_dir_id
@@ -28,7 +29,10 @@ from trestle.oscal.component import (
 from trestlebot.const import FRAMEWORK_SHORT_NAME, SUCCESS_EXIT_CODE
 from trestlebot.tasks.authored.profile import CatalogControlResolver
 from trestlebot.tasks.base_task import TaskBase
-from trestlebot.utils import populate_if_dict_field_not_exist
+from trestlebot.utils import (
+    get_comments_from_yaml_data,
+    populate_if_dict_field_not_exist,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -196,6 +200,36 @@ class SyncOscalCdTask(TaskBase):
 
         return removed_variable, update_variable_value
 
+    def _update_missing_rule_in_memory(
+        self, cac_control: CommentedOrderedMap, missing_rules: List[str]
+    ) -> None:
+        """
+        Add comment to control file for missing rule
+        """
+        # collect all comment in current control, to avoid add duplicate comment
+        exist_comments = get_comments_from_yaml_data(cac_control)
+
+        rule_list = cac_control["rules"]
+
+        # deal with missing rules
+        for missing_rule in missing_rules:
+            logger.warning(
+                f"rule {missing_rule} not exists in cac content repo: {self.cac_content_root}"
+                f" when trying to add to control: {cac_control['id']}"
+            )
+            comment = f"TODO need to implement rule {missing_rule}"
+            # check if missing rule comment already exists
+            if [True for c in exist_comments if comment in c]:
+                continue
+
+            # add comment for missing rule
+            if rule_list:
+                # rules field is non-empty
+                rule_list.yaml_set_comment_before_after_key(0, before=comment)
+            else:
+                # rules field is empty list
+                cac_control.yaml_set_comment_before_after_key("rules", before=comment)
+
     def _update_control_file_change_in_memory(
         self, cac_control: Dict[str, Any], oscal_control: ImplementedRequirement
     ) -> None:
@@ -226,18 +260,22 @@ class SyncOscalCdTask(TaskBase):
         # remove rule
         for rule in set(cac_rule_list).difference(set(oscal_control_rules)):
             rule_list.remove(rule)
+            logger.info(f"Remove rule {rule} from control: {cac_control['id']}")
 
         # add rule
+        missing_rules = []
         for rule in set(oscal_control_rules).difference(set(cac_rule_list)):
             if rule in self.all_rule_ids_from_cac:
                 rule_list.append(rule)
+                logger.info(f"Add rule {rule} to control: {cac_control['id']}")
             else:
-                logger.warning(
-                    f"rule {rule} not exists in cac content repo: {self.cac_content_root}"
-                )
+                missing_rules.append(rule)
+
+        # handle missing rule
+        self._update_missing_rule_in_memory(cac_control, missing_rules)
 
     def _update_profile_change_in_memory(
-        self, profile_data: Dict[str, Any]
+        self, profile_data: Dict[str, Any], profile_id: str
     ) -> List[str]:
         """
         In memory update cac profile changes
@@ -274,6 +312,7 @@ class SyncOscalCdTask(TaskBase):
         # remove rules
         for r in removed_rules:
             selections.remove(r)
+            logger.info(f"remove rule {r} from cac profile {profile_id}")
 
         return policy_ids
 
@@ -322,7 +361,7 @@ class SyncOscalCdTask(TaskBase):
         profile_data = self.read_ordered_data_from_yaml(profile_path)
 
         # Handle selections field, update profile file
-        policy_ids = self._update_profile_change_in_memory(profile_data)
+        policy_ids = self._update_profile_change_in_memory(profile_data, profile_id)
 
         # save profile change
         self.write_ordered_data_to_yaml(profile_path, profile_data, is_profile=True)

--- a/trestlebot/tasks/sync_oscal_content_task.py
+++ b/trestlebot/tasks/sync_oscal_content_task.py
@@ -206,7 +206,7 @@ class SyncOscalCdTask(TaskBase):
         """
         Add comment to control file for missing rule
         """
-        # collect all comment in current control, to avoid add duplicate comment
+        # collect all comments in current control, to avoid adding a duplicate comment
         exist_comments = get_comments_from_yaml_data(cac_control)
 
         rule_list = cac_control["rules"]
@@ -217,7 +217,7 @@ class SyncOscalCdTask(TaskBase):
                 f"rule {missing_rule} not exists in cac content repo: {self.cac_content_root}"
                 f" when trying to add to control: {cac_control['id']}"
             )
-            comment = f"TODO need to implement rule {missing_rule}"
+            comment = f"TODO: Need to implement rule {missing_rule}"
             # check if missing rule comment already exists
             if [True for c in exist_comments if comment in c]:
                 continue

--- a/trestlebot/tasks/sync_oscal_content_task.py
+++ b/trestlebot/tasks/sync_oscal_content_task.py
@@ -168,6 +168,7 @@ class SyncOscalCdTask(TaskBase):
         Read data from yaml file while preserving the order of dictionaries
         """
         yaml = YAML()
+        yaml.preserve_quotes = True
         return yaml.load(file_path)
 
     @staticmethod

--- a/trestlebot/tasks/sync_oscal_content_task.py
+++ b/trestlebot/tasks/sync_oscal_content_task.py
@@ -8,7 +8,7 @@ import pathlib
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedOrderedMap
+from ruamel.yaml.comments import CommentedMap, CommentedOrderedMap
 from ssg.constants import BENCHMARKS
 from ssg.profiles import ProfileSelections, get_profiles_from_products
 from ssg.rules import find_rule_dirs, get_rule_dir_id
@@ -172,16 +172,12 @@ class SyncOscalCdTask(TaskBase):
         return yaml.load(file_path)
 
     @staticmethod
-    def write_ordered_data_to_yaml(
-        file_path: pathlib.Path, data: Any, is_profile: bool = False
-    ) -> None:
+    def write_ordered_data_to_yaml(file_path: pathlib.Path, data: Any) -> None:
         """
         Serializes a Python object into a YAML stream, preserving the order of dictionaries.
         """
         yaml = YAML()
-        # profile indent
-        if is_profile:
-            yaml.indent(mapping=4, sequence=4, offset=4)
+        yaml.indent(mapping=4, sequence=6, offset=4)
         yaml.dump(data, file_path)
 
     def _parse_single_variable(self, variable: str) -> Tuple[List[str], Optional[str]]:
@@ -232,7 +228,7 @@ class SyncOscalCdTask(TaskBase):
                 cac_control.yaml_set_comment_before_after_key("rules", before=comment)
 
     def _update_control_file_change_in_memory(
-        self, cac_control: Dict[str, Any], oscal_control: ImplementedRequirement
+        self, cac_control: CommentedMap, oscal_control: ImplementedRequirement
     ) -> None:
         """
         In memory update cac control file changes
@@ -276,7 +272,7 @@ class SyncOscalCdTask(TaskBase):
         self._update_missing_rule_in_memory(cac_control, missing_rules)
 
     def _update_profile_change_in_memory(
-        self, profile_data: Dict[str, Any], profile_id: str
+        self, profile_data: CommentedMap, profile_id: str
     ) -> List[str]:
         """
         In memory update cac profile changes
@@ -317,7 +313,7 @@ class SyncOscalCdTask(TaskBase):
 
         return policy_ids
 
-    def _handle_controls_field(self, controls_data: List[Dict[str, Any]]) -> None:
+    def _handle_controls_field(self, controls_data: List[CommentedMap]) -> None:
         """
         Handle control file's controls field update
         """
@@ -365,7 +361,7 @@ class SyncOscalCdTask(TaskBase):
         policy_ids = self._update_profile_change_in_memory(profile_data, profile_id)
 
         # save profile change
-        self.write_ordered_data_to_yaml(profile_path, profile_data, is_profile=True)
+        self.write_ordered_data_to_yaml(profile_path, profile_data)
 
         # sync control file
         for policy_id in policy_ids:

--- a/trestlebot/utils.py
+++ b/trestlebot/utils.py
@@ -24,7 +24,7 @@ def populate_if_dict_field_not_exist(
 def get_comments_from_yaml_data(yaml_data: Any) -> List[str]:
     """
     Get all comments from yaml_data, yaml_data must be read
-     using ruamel.yaml library
+    using ruamel.yaml library
     """
     comments: List[str] = []
     if not yaml_data.ca.items:

--- a/trestlebot/utils.py
+++ b/trestlebot/utils.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2024 Red Hat, Inc.
 
 """Common utility functions."""
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from ruamel.yaml import CommentToken
 
 
 def populate_if_dict_field_not_exist(
@@ -17,3 +19,27 @@ def populate_if_dict_field_not_exist(
         data[field_name] = default_value
 
     return data[field_name]
+
+
+def get_comments_from_yaml_data(yaml_data: Any) -> List[str]:
+    """
+    Get all comments from yaml_data, yaml_data must be read
+     using ruamel.yaml library
+    """
+    comments: List[str] = []
+    if not yaml_data.ca.items:
+        return comments
+
+    for _, comment_info in yaml_data.ca.items.items():
+        for comment in comment_info:
+            if not comment:
+                continue
+
+            if isinstance(comment, List):
+                for c in comment:
+                    if isinstance(c, CommentToken):
+                        comments.append(c.value)
+            elif isinstance(comment, CommentToken):
+                comments.append(comment.value)
+
+    return comments

--- a/trestlebot/utils.py
+++ b/trestlebot/utils.py
@@ -2,21 +2,22 @@
 # Copyright (c) 2024 Red Hat, Inc.
 
 """Common utility functions."""
-from typing import Any, Dict, List
+from typing import Any, List
 
-from ruamel.yaml import CommentToken
+from ruamel.yaml import CommentedMap, CommentToken
 
 
 def populate_if_dict_field_not_exist(
-    data: Dict[str, Any], field_name: str, default_value: Any
+    data: CommentedMap, field_name: str, default_value: Any
 ) -> Any:
     """
-    Set field with default value if a dict field does not exist,
+    Set field with default value if a CommentedMap field does not exist,
     if filed exists, this is a no-op
     return field value
     """
     if data.get(field_name) is None:
-        data[field_name] = default_value
+        # insert new filed to -2 position, avoid extra newline
+        data.insert(len(data) - 1, field_name, default_value)
 
     return data[field_name]
 


### PR DESCRIPTION
## Description

Improvement for sync-oscal-content command, Add comment to corresponding control when find missing rule.

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes CPLYTM-608,CPLYTM-609

Example of add comment to control file if rule not exist.

If rules field is empty:

<img width="1388" alt="Screenshot 2025-03-11 at 17 46 56" src="https://github.com/user-attachments/assets/f4e43fe0-1e39-45a1-be72-e9e234b39305" />


If rules is not empty:


<img width="951" alt="Screenshot 2025-03-11 at 17 46 40" src="https://github.com/user-attachments/assets/b0c656be-9766-486c-9180-c83c300608c9" />

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] Manual test
- [x] Unit test

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

