### PR TITLE
fix:  CPLYTM-567 updates for real profile component definition transformation

### DIFF
--- a/trestlebot/tasks/sync_cac_content_task.py
+++ b/trestlebot/tasks/sync_cac_content_task.py
@@ -193,15 +193,18 @@ class SyncCacContentTask(TaskBase):
         for selected in selections:
             if ":" in selected:
                 parts = selected.split(":")
-                if len(parts) == 3:
-                    policy_id, level = parts[0], parts[2]
-                else:
-                    policy_id, level = parts[0], "all"
+                policy_id = parts[0]
                 policy = policies.get(policy_id)
                 if policy is not None:
-                    self.controls.extend(
-                        controls_manager.get_all_controls_of_level(policy_id, level)
-                    )
+                    if len(parts) == 3:
+                        levels = [parts[2]]
+                    else:
+                        levels = [level.id for level in policy.levels]
+
+                    for level in levels:
+                        self.controls.extend(
+                            controls_manager.get_all_controls_of_level(policy_id, level)
+                        )
 
     @staticmethod
     def _build_sections_dict(


### PR DESCRIPTION
## Description

This PR addresses CPLYTM-567: resolving controls from real profiles for transformation of component definitions. The initial issue occurred when the product `profile.yml` selections field indicated "all" levels to be extracted from the associated `policy_id` control file. 

This update excludes the explicit use of "all" levels and provides a more generic approach for accessing the specified levels of the `policy_id`. The policy_id and level associated with the product `profile.yml` will be leveraged to transform real profiles to component definitions. 

**The `sync_cac_content_task` will now:** 

1. Read and extract the `policy_id: level` from selections in the product profile.yml.
2. Capture controls from the control file associated with the selected level. 
3. Then, include those controls in the component definitions transformed from real profiles in the trestle workspace. 

Fixes # CPLYTM-567

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [X] Testing via command line with poetry. 

**Catalog for RHEL9 PCI-DSS**

```zsh

poetry run trestlebot catalog --cac-content-root ~/CaC/forked_content/content 
--policy-id pcidss_4 --repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 
--branch main --committer-email test@redhat.com --committer-name hbraswelrh --dry-run

```

**Profile for RHEL9 PCI-DSS**

```zsh

poetry run trestlebot sync-cac-content profile --product rhel9 
--cac-content-root ~/CaC/forked_content/content --policy-id pcidss_4 
--repo-path ~/demos/tmp-trestle-demos --oscal-catalog pcidss_4 
--committer-name hbraswelrh --committer-email test@redhat.com --branch main --dry-run               

```

**Component Definition for RHEL9 PCI-DSS**

```zsh

poetry run trestlebot sync-cac-content component-definition 
--product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile pci-dss 
--repo-path ~/demos/tmp-trestle-demos --oscal-profile pcidss_4-base 
--component-definition-type software --committer-name hbraswelrh 
--committer-email test@redhat.com --branch main --dry-run

```

**Note:** Left side of terminal is where trestle-bot commands are run. Right side is trestle workspace where content is populated.

![image](https://github.com/user-attachments/assets/0aa30620-b721-4ea9-bf55-c8a336c7ce4c)

- [X] GitHub Actions 

**Test Configuration**:

- Firmware version: N40ET47W (1.29 )
- Hardware: Lenovo ThinkPad P1 Gen 4i
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
