### PR TITLE
fix: CPLYTM-632 use description from cac profile as prose

### DIFF
--- a/trestlebot/tasks/sync_cac_catalog_task.py
+++ b/trestlebot/tasks/sync_cac_catalog_task.py
@@ -106,7 +106,11 @@ def control_cac_to_oscal(
                     f"{cac_control_id}_prm_{assignment_id}", ""
                 )
             oscal_control.parts.append(
-                common.Part(id=f"{cac_control_id}_smt", name=common_const.STATEMENT)
+                common.Part(
+                    id=f"{cac_control_id}_smt",
+                    name=common_const.STATEMENT,
+                    prose=cac_control.description,
+                )
             )
 
         guidance = re.search(


### PR DESCRIPTION
## Description

There is an existing bug in which the description from the CaC control is not being populated within the `Control Statement` of the control in the OSCAL catalog.  This PR solves the issue by adding the description as the prose in the control parts.

Fixes CPLYTM-632

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

The fix can be verified by running the `trestlebot sync-cac-content catalog` command to create a catalog from a CaC control file.  Then observing the `prose` field in the control parts.  Example:

```
            "parts": [
              {
                "id": "r80_smt",
                "name": "statement",
                "prose": "All network services must be listening on the correct network intefaces."
              }
            ]
```

![image](https://github.com/user-attachments/assets/ebd7b9a4-e988-48e4-b38e-4cec7a6380fe)


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
