### PR TITLE
feat: CPLYTM-656 CPLYTM-655 Create non-exist variables value in cac side when sync OSCAL CD

### DIFF
--- a/docs/tutorials/sync-oscal-content.md
+++ b/docs/tutorials/sync-oscal-content.md
@@ -13,6 +13,7 @@ The CLI performs the following sync:
 - Sync OSCAL component definition parameters/rules changes to CaC content profile file
 - Sync OSCAL component definition parameters/rules changes to CaC content control file
 - Add a hint comment to the control file when a missing rule is found in the CaC content repo.
+- Add new option to cac var file when found variable exists but missing the option we sync.
 
 ### 1. Prerequisites
 

--- a/tests/data/json/rhel8.json
+++ b/tests/data/json/rhel8.json
@@ -174,7 +174,7 @@
               {
                 "param-id": "var_system_crypto_policy",
                 "values": [
-                  "future"
+                  "not-exist-option"
                 ]
               },
               {

--- a/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
@@ -97,10 +97,21 @@ def test_sync_oscal_cd_to_cac_control(
             assert len([True for c in exist_comments if comment in c]) == 1
             rules = control.get("rules", [])
             assert "file_groupownership_sshd_private_key" not in rules
-            assert "var_system_crypto_policy=future" in rules
+            assert "var_system_crypto_policy=not-exist-option" in rules
             assert "var_sshd_set_keepalive=1" not in rules
             assert "not_exist_rule_id" not in rules
             assert "configure_crypto_policy" in rules
         elif control["id"] == "AC-2":
             rules = control.get("rules", [])
             assert rules == []
+
+    # check var file
+    var_file_path = pathlib.Path(
+        os.path.join(
+            tmp_content_dir, "linux_os/guide/test/var_system_crypto_policy.var"
+        )
+    )
+    var_file_data = yaml.load(var_file_path)
+    options = var_file_data["options"]
+    assert "not-exist-option" in options
+    assert options["not-exist-option"] == "not-exist-option"

--- a/trestlebot/tasks/sync_oscal_content_task.py
+++ b/trestlebot/tasks/sync_oscal_content_task.py
@@ -96,7 +96,9 @@ class ParameterDiffInfo:
                 except ScannerError:
                     # currently some var file contains Jinja2 macros,
                     # temporarily ignore this exception
-                    pass
+                    logger.warning(
+                        f"process {v_file} failed, this file may contains Jinja2 marcos"
+                    )
 
                 break
 

--- a/trestlebot/utils.py
+++ b/trestlebot/utils.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2024 Red Hat, Inc.
 
 """Common utility functions."""
+import pathlib
 from typing import Any, List
 
-from ruamel.yaml import CommentedMap, CommentToken
+from ruamel.yaml import YAML, CommentedMap, CommentToken
 
 
 def populate_if_dict_field_not_exist(
@@ -44,3 +45,21 @@ def get_comments_from_yaml_data(yaml_data: Any) -> List[str]:
                 comments.append(comment.value)
 
     return comments
+
+
+def read_cac_yaml_ordered(file_path: pathlib.Path) -> Any:
+    """
+    Read data from cac content yaml file while preserving the order
+    """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    return yaml.load(file_path)
+
+
+def write_cac_yaml_ordered(file_path: pathlib.Path, data: Any) -> None:
+    """
+    Serializes a Python object into a cac content YAML stream, preserving the order.
+    """
+    yaml = YAML()
+    yaml.indent(mapping=4, sequence=6, offset=4)
+    yaml.dump(data, file_path)

--- a/trestlebot/utils.py
+++ b/trestlebot/utils.py
@@ -49,7 +49,7 @@ def get_comments_from_yaml_data(yaml_data: Any) -> List[str]:
 
 def read_cac_yaml_ordered(file_path: pathlib.Path) -> Any:
     """
-    Read data from cac content yaml file while preserving the order
+    Read data from CaC content yaml file while preserving the order
     """
     yaml = YAML()
     yaml.preserve_quotes = True
@@ -58,7 +58,7 @@ def read_cac_yaml_ordered(file_path: pathlib.Path) -> Any:
 
 def write_cac_yaml_ordered(file_path: pathlib.Path, data: Any) -> None:
     """
-    Serializes a Python object into a cac content YAML stream, preserving the order.
+    Serializes a Python object into a CaC content YAML stream, preserving the order.
     """
     yaml = YAML()
     yaml.indent(mapping=4, sequence=6, offset=4)


### PR DESCRIPTION
## Description

Improvement for `sync-oscal-content cac-control` command.Create non-exist variables value in cac content var file when sync OSCAL component definition.

<img width="1124" alt="Screenshot 2025-03-27 at 12 58 14" src="https://github.com/user-attachments/assets/8ef3e31b-016d-4bb4-802f-fd346a2da2de" />


<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes CPLYTM-656

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] Manual test
- [x] Unit test

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
