### PR TITLE
fix: CPLYTM-710 updating logger statements

### DIFF
--- a/trestlebot/tasks/sync_cac_content_task.py
+++ b/trestlebot/tasks/sync_cac_content_task.py
@@ -467,6 +467,9 @@ class SyncCacContentTask(TaskBase):
             ModelUtils.update_last_modified(compdef)
             compdef.oscal_write(cd_json)
             logger.info(f"Component definition: {cd_json} is updated")
+            logger.debug(
+                f"Component definition: {cd_json} was updated for {self.product}."
+            )
         else:
             logger.info(f"No update in component definition: {cd_json}")
 
@@ -482,6 +485,7 @@ class SyncCacContentTask(TaskBase):
         cd_dir.mkdir(exist_ok=True, parents=True)
         component_definition.components.append(oscal_component)
         component_definition.oscal_write(cd_json)
+        logger.debug(f"Component definition: {cd_json} was created for {self.product}.")
 
     def _create_or_update_compdef(self) -> None:
         """Create or update component definition for specified CaC profile."""
@@ -500,9 +504,15 @@ class SyncCacContentTask(TaskBase):
         if cd_json.exists():
             logger.info(f"The component definition for {self.product} exists.")
             self._update_compdef(cd_json, oscal_component)
+            logger.debug(
+                f"The component definition for {self.product} was updated at {cd_json}."
+            )
         else:
             logger.info(f"Creating component definition for product {self.product}")
             self._create_compdef(cd_json, oscal_component)
+            logger.debug(
+                f"The component definition for {self.product} was created at {cd_json}."
+            )
 
     def execute(self) -> int:
         """Execute task to create or update product component definition."""


### PR DESCRIPTION
## Description

This PR proposes a minor update to the logger statements that are returned for `--debug` for the `sync_cac_content component-definition` command. The update will provide the location and product name where transformed OSCAL Component Definitions have been updated or created in the trestlebot workspace. 

CPLYTM-710

Depends on #532 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Tested by transforming content via command line:
```bash
poetry run trestlebot sync-cac-content component-definition --product rhel9 --cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_high --repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-high --component-definition-type software --committer-name hbraswelrh --committer-email test@redhat.com --branch main --dry-run
```
- [ ] Pass flag `--debug` when creating or updating component definitions

**Test Configuration**:

- Firmware version: N40ET47W (1.29 )
- Hardware: Lenovo ThinkPad P1 Gen 4i
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
