### PR TITLE
fix: CPLYTM-740 updates sync_cac_content_catalog task to set empty values to None

### DIFF
--- a/trestlebot/tasks/sync_cac_catalog_task.py
+++ b/trestlebot/tasks/sync_cac_catalog_task.py
@@ -15,6 +15,7 @@ from typing import List, Optional
 import ssg
 from ssg.controls import Policy
 from trestle.common import const as common_const
+from trestle.common.list_utils import none_if_empty
 from trestle.common.model_utils import ModelUtils
 from trestle.core.generators import generate_sample_model
 from trestle.core.models.file_content_type import FileContentType
@@ -125,6 +126,12 @@ def control_cac_to_oscal(
                     id=f"{cac_control_id}_gdn", name="guidance", prose=guidance.group(1)
                 )
             )
+
+    # Ensure any empty values are set to None as these
+    # lists cannot be empty
+    oscal_control.props = none_if_empty(oscal_control.props)
+    oscal_control.params = none_if_empty(oscal_control.params)
+    oscal_control.parts = none_if_empty(oscal_control.parts)
     return oscal_control
 
 
@@ -289,6 +296,11 @@ class SyncCacCatalogTask(TaskBase):
             # oscal_catalog.back_matter = None
 
         self._sync_catalog(oscal_catalog, policy)
+
+        # Ensure any empty values are set to one as these
+        # lists cannot be empty
+        oscal_catalog.params = none_if_empty(oscal_catalog.params)
+        oscal_catalog.groups = none_if_empty(oscal_catalog.groups)
 
         catalog_dir = pathlib.Path(os.path.dirname(oscal_json))
         catalog_dir.mkdir(exist_ok=True, parents=True)

--- a/trestlebot/tasks/sync_cac_catalog_task.py
+++ b/trestlebot/tasks/sync_cac_catalog_task.py
@@ -297,7 +297,7 @@ class SyncCacCatalogTask(TaskBase):
 
         self._sync_catalog(oscal_catalog, policy)
 
-        # Ensure any empty values are set to one as these
+        # Ensure any empty values are set to None as these
         # lists cannot be empty
         oscal_catalog.params = none_if_empty(oscal_catalog.params)
         oscal_catalog.groups = none_if_empty(oscal_catalog.groups)


### PR DESCRIPTION
## Description

Update the `sync_cac_content` catalog task to ensure the output is OSCAL schema compliant.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Created a new catalog using
```bash
poetry run trestlebot sync-cac-content catalog --dry-run --repo-path ~/trestlebot-workspace --committer-email test@redhat.com --committer-name test --branch main --cac-content-root ~/content --oscal-catalog anssi --cac-policy-id anssi
```
- [X] Copied the catalog to the `complytime` application directory and ran `complytime scan --with-md`

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
