### PR TITLE
feat: CPLYTM-753 Introduce catalog subcommand for sync-oscal-content

### DIFF
--- a/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
@@ -18,6 +18,7 @@ from tests.testutils import (
     setup_for_profile,
 )
 from trestlebot.cli.commands.sync_oscal_content import (
+    sync_oscal_catalog_to_cac_content_cmd,
     sync_oscal_cd_to_cac_content_cmd,
     sync_oscal_content_cmd,
     sync_oscal_profile_to_cac_content_cmd,
@@ -383,3 +384,39 @@ def test_sync_oscal_profile_levels_high_to_low(
         elif control["id"] == "AC-2":
             levels = control["levels"]
             assert levels == ["medium"]
+
+
+def test_sync_oscal_catalog_cmd(tmp_repo: Tuple[str, Repo], tmp_init_dir: str) -> None:
+    """Tests that sync-oscal-content catalog command."""
+    repo_dir, _ = tmp_repo
+    trestle_repo_path = pathlib.Path(repo_dir)
+    setup_for_compdef(
+        trestle_repo_path,
+        test_product,
+        test_product,
+        model_name=os.path.join(test_product, test_profile_name),
+    )
+    tmp_content_dir = tmp_init_dir
+    setup_for_cac_content_dir(tmp_content_dir, test_content_dir)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        sync_oscal_catalog_to_cac_content_cmd,
+        [
+            "--cac-policy-id",
+            test_policy_id,
+            "--cac-content-root",
+            tmp_content_dir,
+            "--repo-path",
+            str(trestle_repo_path.resolve()),
+            "--committer-email",
+            "test@email.com",
+            "--committer-name",
+            "test name",
+            "--branch",
+            "test",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == SUCCESS_EXIT_CODE, result.output

--- a/trestlebot/cli/commands/sync_oscal_content.py
+++ b/trestlebot/cli/commands/sync_oscal_content.py
@@ -11,6 +11,7 @@ import click
 from trestlebot.cli.options.common import common_options, git_options, handle_exceptions
 from trestlebot.cli.utils import run_bot
 from trestlebot.tasks.base_task import TaskBase
+from trestlebot.tasks.sync_oscal_content_catalog_task import SyncOscalCatalogTask
 from trestlebot.tasks.sync_oscal_content_cd_task import SyncOscalCdTask
 from trestlebot.tasks.sync_oscal_content_profile_task import SyncOscalProfileTask
 
@@ -120,6 +121,49 @@ def sync_oscal_profile_to_cac_content_cmd(
         working_dir=working_dir,
         cac_policy_id=cac_policy_id,
         product=product,
+    )
+    pre_tasks.append(sync_cac_content_task)
+    # change working_dir to CaC content repo, since this task changing
+    # CaC content
+    kwargs["repo_path"] = str(cac_content_root.resolve())
+    result = run_bot(pre_tasks, kwargs)
+    logger.debug(f"Trestlebot results: {result}")
+
+
+@sync_oscal_content_cmd.command(
+    name="catalog",
+    help="Sync OSCAL catalog information to cac content.",
+)
+@click.pass_context
+@common_options
+@git_options
+@click.option(
+    "--cac-content-root",
+    help="Root of the CaC content project.",
+    type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, path_type=pathlib.Path
+    ),
+    required=True,
+)
+@click.option(
+    "--cac-policy-id",
+    type=str,
+    required=True,
+    help="Policy id for source control file.",
+)
+def sync_oscal_catalog_to_cac_content_cmd(
+    ctx: click.Context,
+    cac_content_root: pathlib.Path,
+    cac_policy_id: str,
+    **kwargs: Any,
+) -> None:
+    """Sync OSCAL catalog to CaC control file"""
+    working_dir = kwargs["repo_path"]  # From common_options
+    pre_tasks: List[TaskBase] = []
+    sync_cac_content_task = SyncOscalCatalogTask(
+        cac_content_root=cac_content_root,
+        working_dir=working_dir,
+        cac_policy_id=cac_policy_id,
     )
     pre_tasks.append(sync_cac_content_task)
     # change working_dir to CaC content repo, since this task changing

--- a/trestlebot/tasks/sync_oscal_content_catalog_task.py
+++ b/trestlebot/tasks/sync_oscal_content_catalog_task.py
@@ -1,0 +1,26 @@
+import logging
+import pathlib
+
+from trestlebot.const import SUCCESS_EXIT_CODE
+from trestlebot.tasks.base_task import TaskBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class SyncOscalCatalogTask(TaskBase):
+    """Sync OSCAL catalog to CaC content task."""
+
+    def __init__(
+        self,
+        cac_content_root: pathlib.Path,
+        working_dir: str,
+        cac_policy_id: str,
+    ) -> None:
+        """Initialize task."""
+        super().__init__(working_dir, None)
+        self.cac_content_root = cac_content_root
+        self.cac_policy_id = cac_policy_id
+
+    def execute(self) -> int:
+        return SUCCESS_EXIT_CODE


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes # (issue)

Introduce catalog subcommand for sync-oscal-content, this PR only introduce new command, implementation will in other PR.

`poetry run trestlebot sync-oscal-content catalog --cac-policy-id nist_ocp4 --cac-content-root ~/content --repo-path ~/trestlebot-workspace --committer-name test --committer-email test@redhat.com --branch main --dry-run`


## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] Local test
- [x] Unit test

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
