### PR TITLE
chore: remove the ignored SRG controls

### DIFF
--- a/scripts/get_rule_impacted_files.py
+++ b/scripts/get_rule_impacted_files.py
@@ -48,6 +48,8 @@ def main(product, content_root_dir, search_rule, file_type="control"):
     else:
         directory = f"{content_root_dir}/products/{product}/profiles"
     files = find_files_with_string(directory, search_rule)
+    exclude_string = "SRG-"
+    files = [file for file in files if exclude_string not in file]
     files = set(files)
     logging.info(" ".join(files))
 


### PR DESCRIPTION
## Description
This script filters the related controls and profiles of the updated rules and variables.  In the impacted controls, the SRG* controls could be ignored safely. To improve the efficiency of the CI sync-cac-oscal workflow, this PR would like to remove the SRG* controls.

Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
`python scripts/get_rule_impacted_files.py rhel9 "/Users/huiwang/huiwang-fork/cac-content" "dconf_db_up_to_date" control`
Original output as follows:
`ccn_ol9 cis_rhel10 stig_ol9 stig_rhel9 ccn_rhel9 cis_almalinux9 cis_rhel9 cis_sle15 hipaa pcidss_3 SRG-OS-000480-GPOS-00227 cis_rhel8 cis_sle12 pcidss_4`
The new output looks as follows:
`hipaa cis_almalinux9 ccn_rhel9 cis_sle15 cis_rhel8 cis_sle12 ccn_ol9 cis_rhel10 pcidss_3 pcidss_4 cis_rhel9 stig_ol9 stig_rhel9`

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
