### PR TITLE
feat: CPLYTM-754 Implement sync-oscal-content catalog command

### DIFF
--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -190,10 +190,15 @@ def setup_for_profile(
 
 
 def setup_for_catalog(
-    tmp_trestle_dir: pathlib.Path, cat_name: str, output_name: str
+    tmp_trestle_dir: pathlib.Path,
+    cat_name: str,
+    output_name: str,
+    model_name: Optional[str] = None,
 ) -> argparse.Namespace:
     """Setup trestle temp directory for catalog testing"""
-    load_from_json(tmp_trestle_dir, cat_name, cat_name, cat.Catalog)  # type: ignore
+    if model_name is None:
+        model_name = cat_name
+    path = load_from_json(tmp_trestle_dir, cat_name, model_name, cat.Catalog)  # type: ignore
     args = argparse.Namespace(
         trestle_root=tmp_trestle_dir,
         name=cat_name,
@@ -202,6 +207,8 @@ def setup_for_catalog(
         overwrite_header_values=False,
         yaml_header=None,
         force_overwrite=None,
+        model_name=model_name,
+        path=path,
     )
 
     return args

--- a/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_oscal_content_cmd.py
@@ -14,6 +14,7 @@ from ruamel.yaml import YAML
 from tests.testutils import (
     TEST_DATA_DIR,
     setup_for_cac_content_dir,
+    setup_for_catalog,
     setup_for_compdef,
     setup_for_profile,
 )
@@ -33,6 +34,7 @@ test_product = "rhel8"
 test_content_dir = TEST_DATA_DIR / "content_dir"
 test_policy_id = "abcd-levels"
 test_profile_name = "simplified_nist_profile"
+test_catalog_name = "simplified_nist_catalog"
 
 
 def test_invalid_sync_oscal_cmd() -> None:
@@ -102,7 +104,7 @@ def test_sync_oscal_cd_to_cac_control(
 
     # check control file
     control_file_path = pathlib.Path(
-        os.path.join(tmp_content_dir, "controls", "abcd-levels.yml")
+        os.path.join(tmp_content_dir, "controls", f"{test_policy_id}.yml")
     )
     control_file_data = yaml.load(control_file_path)
     for control in control_file_data["controls"]:
@@ -219,7 +221,7 @@ def test_sync_oscal_cd_statements(
 
     # check control file
     control_file_path = pathlib.Path(
-        os.path.join(tmp_content_dir, "controls", "abcd-levels.yml")
+        os.path.join(tmp_content_dir, "controls", f"{test_policy_id}.yml")
     )
     control_file_data = yaml.load(control_file_path)
     for control in control_file_data["controls"]:
@@ -290,7 +292,7 @@ def test_sync_oscal_profile_levels_low_to_high(
     # check level change
     yaml = YAML()
     control_file_path = pathlib.Path(
-        os.path.join(tmp_content_dir, "controls", "abcd-levels.yml")
+        os.path.join(tmp_content_dir, "controls", f"{test_policy_id}.yml")
     )
     control_file_data = yaml.load(control_file_path)
     for control in control_file_data["controls"]:
@@ -341,7 +343,7 @@ def test_sync_oscal_profile_levels_high_to_low(
     yaml = YAML()
     # change control file for test
     control_file_path = pathlib.Path(
-        os.path.join(tmp_content_dir, "controls", "abcd-levels.yml")
+        os.path.join(tmp_content_dir, "controls", f"{test_policy_id}.yml")
     )
     control_file_data = yaml.load(control_file_path)
     for control in control_file_data["controls"]:
@@ -387,14 +389,14 @@ def test_sync_oscal_profile_levels_high_to_low(
 
 
 def test_sync_oscal_catalog_cmd(tmp_repo: Tuple[str, Repo], tmp_init_dir: str) -> None:
-    """Tests that sync-oscal-content catalog command."""
+    """Tests sync-oscal-content catalog command."""
     repo_dir, _ = tmp_repo
     trestle_repo_path = pathlib.Path(repo_dir)
-    setup_for_compdef(
+    setup_for_catalog(
         trestle_repo_path,
-        test_product,
-        test_product,
-        model_name=os.path.join(test_product, test_profile_name),
+        test_catalog_name,
+        test_catalog_name,
+        model_name=test_policy_id,
     )
     tmp_content_dir = tmp_init_dir
     setup_for_cac_content_dir(tmp_content_dir, test_content_dir)
@@ -420,3 +422,16 @@ def test_sync_oscal_catalog_cmd(tmp_repo: Tuple[str, Repo], tmp_init_dir: str) -
     )
 
     assert result.exit_code == SUCCESS_EXIT_CODE, result.output
+
+    # check description change
+    yaml = YAML()
+    # change control file for test
+    control_file_path = pathlib.Path(
+        os.path.join(tmp_content_dir, "controls", f"{test_policy_id}.yml")
+    )
+    control_file_data = yaml.load(control_file_path)
+    for control in control_file_data["controls"]:
+        if control["id"] == "AC-1":
+            assert control["description"] == "The organization:"
+        elif control["id"] == "AC-2":
+            assert control.get("description") is None

--- a/trestlebot/tasks/sync_oscal_content_catalog_task.py
+++ b/trestlebot/tasks/sync_oscal_content_catalog_task.py
@@ -1,8 +1,21 @@
 import logging
 import pathlib
+from typing import Dict
+
+from ruamel.yaml import CommentedMap
+from trestle.common.model_utils import ModelUtils
+from trestle.core.catalog.catalog_interface import CatalogInterface
+from trestle.core.control_interface import ControlInterface
+from trestle.core.models.file_content_type import FileContentType
+from trestle.oscal.catalog import Catalog, Control
 
 from trestlebot.const import SUCCESS_EXIT_CODE
 from trestlebot.tasks.base_task import TaskBase
+from trestlebot.utils import (
+    populate_if_dict_field_not_exist,
+    read_cac_yaml_ordered,
+    write_cac_yaml_ordered,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -21,6 +34,82 @@ class SyncOscalCatalogTask(TaskBase):
         super().__init__(working_dir, None)
         self.cac_content_root = cac_content_root
         self.cac_policy_id = cac_policy_id
+        self.catalog_controls: Dict[str, Control] = {}
+        self.control_file_path = pathlib.Path(
+            self.cac_content_root, "controls", f"{self.cac_policy_id}.yml"
+        )
+        self.oscal_to_cac_map: Dict[str, str] = {}
+
+    def get_catalog_controls(self, catalog: Catalog) -> Dict[str, Control]:
+        """
+        Get all controls from a catalog.
+        """
+        controls = {
+            control.id: control
+            for control in CatalogInterface(catalog).get_all_controls_from_catalog(
+                recurse=True
+            )
+        }
+        return controls
+
+    def get_oscal_to_cac_map(self, catalog: Catalog) -> Dict[str, str]:
+        """
+        Get oscal_control_id to cac_control_id map
+        """
+        result = {}
+        for control in CatalogInterface(catalog).get_all_controls_from_catalog(
+            recurse=True
+        ):
+            label = ControlInterface.get_label(control)
+            if label:
+                result[control.id] = label
+
+        return result
+
+    def sync_description(self, cac_control_map: Dict[str, CommentedMap]) -> None:
+        """
+        Sync OSCAL catalog parts field to CaC control file description field
+        """
+        for oscal_control_id, oscal_control in self.catalog_controls.items():
+            cac_control_id = self.oscal_to_cac_map.get(oscal_control_id)
+            if not cac_control_id:
+                continue
+
+            cac_control = cac_control_map.get(cac_control_id)
+            if not cac_control:
+                continue
+            parts_statement = ControlInterface.get_part_prose(
+                oscal_control, "statement"
+            )
+            description = cac_control.get("description")
+            if not description and not parts_statement:
+                continue
+
+            populate_if_dict_field_not_exist(cac_control, "description", "")
+            cac_control["description"] = parts_statement
+
+    def sync_oscal_catalog(self) -> None:
+        """
+        Sync OSCAL catalog information to CaC control file.
+        """
+        data = read_cac_yaml_ordered(self.control_file_path)
+        cac_control_map = {
+            control["id"]: control for control in data.get("controls", [])
+        }
+        self.sync_description(cac_control_map)
+        write_cac_yaml_ordered(self.control_file_path, data)
 
     def execute(self) -> int:
+        oscal_json = ModelUtils.get_model_path_for_name_and_class(
+            self.working_dir, self.cac_policy_id, Catalog, FileContentType.JSON
+        )
+
+        if not oscal_json.exists():
+            raise RuntimeError(f"{oscal_json} does not exist")
+
+        oscal_catalog = Catalog.oscal_read(oscal_json)
+        self.catalog_controls = self.get_catalog_controls(oscal_catalog)
+        self.oscal_to_cac_map = self.get_oscal_to_cac_map(oscal_catalog)
+        self.sync_oscal_catalog()
+
         return SUCCESS_EXIT_CODE


### PR DESCRIPTION
## Summary

Implement sync-oscal-content catalog command

## Related Issues

- Closes CPLYTM-754

## Review Hints

### Relationship between OSCAL catalog control parts field and CaC control file control description field

<img width="2105" alt="Screenshot 2025-05-26 at 18 26 22" src="https://github.com/user-attachments/assets/6dc5b29e-32bf-4d3c-bbac-eb75a8515d28" />
<img width="1430" alt="Screenshot 2025-05-26 at 18 26 31" src="https://github.com/user-attachments/assets/b1860d79-8960-47a2-a1d3-1b0000b13d44" />

On OSCAL side, `parts` field corresponding to CaC control file control `description` field, part named `statement` contains full data from  CaC `description` field, and part named `guidance` contains data begin with `Supplemental Guidance:` from  CaC `description` field.

### How to test?

Modify catalog control `parts` field in trestle workplace, then run command `poetry run trestlebot sync-oscal-content catalog --cac-policy-id nist_ocp4  --cac-content-root ~/content --repo-path ~/trestlebot-workspace --committer-name test --committer-email test@redhat.com --branch main --dry-run`. After that, check corresponding change in CaC side(control description field in control file).
