### PR TITLE
chore: update the ocp4 control name

### DIFF
--- a/scripts/get_rule_impacted_files.py
+++ b/scripts/get_rule_impacted_files.py
@@ -45,11 +45,15 @@ def find_files_with_string(directory, search_string) -> List:
 def main(product, content_root_dir, search_rule, file_type="control"):
     if file_type == "control":
         directory = f"{content_root_dir}/controls/"
+        files = find_files_with_string(directory, search_rule)
+        exclude_string = "SRG-"
+        files = [file for file in files if exclude_string not in file]
+        for i in range(1, len(files)):
+            if "section-" in files[i]:
+                files[i] = "cis_ocp_1_4_0"
     else:
         directory = f"{content_root_dir}/products/{product}/profiles"
-    files = find_files_with_string(directory, search_rule)
-    exclude_string = "SRG-"
-    files = [file for file in files if exclude_string not in file]
+        files = find_files_with_string(directory, search_rule)
     files = set(files)
     logging.info(" ".join(files))
 


### PR DESCRIPTION
## Summary
This module is designed to get the controls and profiles that are impacted by
the updated rule. It is useful to determine how to sync the updated rule
to OSCAL component-definition.
When filtering the control file, like `controls/cis_ocp_1_4_0/section-1.yml`, the `control` or `policy_id` should be "cis_ocp_1_4_0" for the product ocp4. 

## Review Hints

`python get_rule_impacted_files.py rhel8 "/Users/huiwang/huiwang-fork/cac-content" file_permissions_kube_apiserver control
`