### PR TITLE
ci: CPLYTM-820 CPLYTM-821 - ensure release pr is triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
-name: Draft a Trestle-Bot release PR
+name: Release PR
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Currently we have a release cadence of about three weeks and in the meantime it is not necessary to keep a release PR open consuming CI resources whenever a PR is merged into main. When we are closer to a release, we can manually trigger this workflow. This will also allow CI tests to be executed on it.

## Related Issues

Avoid spending CI resources and fix the issue of now executing CI tests on release PRs.

## Review Hints

Current release PR:
- https://github.com/complytime/trestle-bot/pull/567

Jobs:
- https://github.com/complytime/trestle-bot/actions/workflows/release.yml